### PR TITLE
Update dd-aas-junkyard-load-v4.yml

### DIFF
--- a/.github/workflows/dd-aas-junkyard-load-v4.yml
+++ b/.github/workflows/dd-aas-junkyard-load-v4.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Publish
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}"
     - name: Publish Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: functionapp
         path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}

--- a/.github/workflows/dd-aas-junkyard-load-v4.yml
+++ b/.github/workflows/dd-aas-junkyard-load-v4.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Publish
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}"
     - name: Publish Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: functionapp
         path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}


### PR DESCRIPTION
This action failed: https://github.com/DataDog/dotnet-aas-samples/actions/runs/14777907004/job/41490154500

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/